### PR TITLE
Remove hard coded solution in favor of field annotation

### DIFF
--- a/PmiRdrModule.php
+++ b/PmiRdrModule.php
@@ -11,8 +11,6 @@ class PmiRdrModule extends \ExternalModules\AbstractExternalModule {
     const RECORD_CREATED_BY_MODULE = "rdr_module_created_this_";
     const RDR_CACHE_STATUS = "cache_status";
     const RDR_CACHE_SNAPSHOTS = "current_snapshots";
-    // Used when sending Research Access Board Complete projects to <RDR-Env>/rdr/v1/workbench/audit/workspace/results
-    const RAB_REVIEW_TYPE = 'RAB';
 
 	public function __construct() {
 		parent::__construct();
@@ -137,39 +135,37 @@ class PmiRdrModule extends \ExternalModules\AbstractExternalModule {
 						foreach($apiNestedFields as $tempField) {
 							$importPlace = &$importPlace[$tempField];
 						}
-
-                        $value = $data[$redcapField];
-                        if ($metadata[$redcapField]["field_type"] == "checkbox") {
-                            $value = [];
-                            if ($redcapField == 'rw_workspace_review_status2' && $apiField == 'reviewType') {
-                                // hardcode this for all review types related to RAB as the condition for sending across the API is a complete status (condition: [rw_workspace_review_status2(8)] = '1')
-                                $value = self::RAB_REVIEW_TYPE;
-                            } else {
+                        // Check for hardcoded value in the field annotation first.
+                        $hardcodedValue = $this->getHardCodedValue($metadata[$redcapField]);
+                        if ($hardcodedValue) {
+                            $importPlace = $hardcodedValue;
+                        } else {
+                            $value = $data[$redcapField];
+                            if ($metadata[$redcapField]["field_type"] == "checkbox") {
+                                $value = [];
                                 foreach ($data[$redcapField] as $checkboxRaw => $checkboxChecked) {
                                     if ($checkboxChecked == 1) {
                                         $value[] = $checkboxRaw;
                                     }
                                 }
+                            } else if ($metadata[$redcapField]["field_type"] == "yesno") {
+                                $value = boolval($value);
+                            } else if (is_numeric($value)) {
+                                $value = (int)$value;
                             }
+                            $importPlace = $value;
                         }
-						else if($metadata[$redcapField]["field_type"] == "yesno") {
-							$value = boolval($value);
-						}
-						else if(is_numeric($value)) {
-							$value = (int)$value;
-						}
-						$importPlace = $value;
-					}
+                    }
 				}
 
 				if(!empty($exportData)) {
 					$exportData = [$exportData];
-	//				$results = $httpClient->post($thisUrl,["form_params" => $exportData]);
+                    //$results = $httpClient->post($thisUrl,["form_params" => $exportData]);
 
-	//				$exportData = json_encode($exportData);
-					## TODO Temp test string to see if works
-					//$exportData = '[{"userId": 5000,"creationTime": "2020-03-15T21:21:13.056Z","modifiedTime": "2020-03-15T21:21:13.056Z","givenName": "REDCap test","familyName": "REDCap test","email": "redcap_test@xxx.com","streetAddress1": "REDCap test","streetAddress2": "REDCap test","city": "REDCap test","state": "REDCap test","zipCode": "00000","country": "usa","ethnicity": "HISPANIC","sexAtBirth": ["FEMALE", "INTERSEX"],"identifiesAsLgbtq": false,"lgbtqIdentity": "REDCap test","gender": ["MAN", "WOMAN"],"race": ["AIAN", "WHITE"],"education": "COLLEGE_GRADUATE","degree": ["PHD", "MBA"],"disability": "YES","affiliations": [{"institution": "REDCap test","role": "REDCap test","nonAcademicAffiliation": "INDUSTRY"}],"verifiedInstitutionalAffiliation": {"institutionShortName": "REDCap test","institutionalRole": "REDCap test"}}]';
-					//$exportData = json_decode($exportData,true);
+                    //$exportData = json_encode($exportData);
+                    ## TODO Temp test string to see if works
+                    //$exportData = '[{"userId": 5000,"creationTime": "2020-03-15T21:21:13.056Z","modifiedTime": "2020-03-15T21:21:13.056Z","givenName": "REDCap test","familyName": "REDCap test","email": "redcap_test@xxx.com","streetAddress1": "REDCap test","streetAddress2": "REDCap test","city": "REDCap test","state": "REDCap test","zipCode": "00000","country": "usa","ethnicity": "HISPANIC","sexAtBirth": ["FEMALE", "INTERSEX"],"identifiesAsLgbtq": false,"lgbtqIdentity": "REDCap test","gender": ["MAN", "WOMAN"],"race": ["AIAN", "WHITE"],"education": "COLLEGE_GRADUATE","degree": ["PHD", "MBA"],"disability": "YES","affiliations": [{"institution": "REDCap test","role": "REDCap test","nonAcademicAffiliation": "INDUSTRY"}],"verifiedInstitutionalAffiliation": {"institutionShortName": "REDCap test","institutionalRole": "REDCap test"}}]';
+                    //$exportData = json_decode($exportData,true);
 
 					if($testingOnly[$urlKey] != 1) {
 						$results = $httpClient->post($thisUrl,["json" => $exportData]);
@@ -901,4 +897,21 @@ class PmiRdrModule extends \ExternalModules\AbstractExternalModule {
 			die();
 		}
 	}
+
+    /**
+     * Helper method to find any values that should be hardcoded
+     * @param $metadataArray
+     * @return false|mixed
+     */
+    private function getHardCodedValue($metadataArray)
+    {
+        if (isset($metadataArray['field_annotation']) && str_contains($metadataArray['field_annotation'], 'pmiRdrHardCodeValue')) {
+            $matches = [];
+            $s = preg_match('/(?<=\")(.*?)(?=\")/', $metadataArray['field_annotation'], $matches);
+            if ($s > 0) {
+                return $matches[1];
+            }
+        }
+        return false;
+    }
 }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # PmiRdrModule
 Connects PMI REDCap to the RDR
+
+## Configuration
+This module has many configuration options. Please review them in `config.json`.
+
+## `pmiRdrHardCodeValue` and `@DEFAULT` Action Tags
+When using the "Push Record on Save" configuration, this module uses two action tags
+
+### `pmiRdrHardCodeValue`
+Using this tag like `pmiRdrHardCodeValue="???"` will hard-code a value in the API payload. 
+
+### `@DEFAULT="???"`
+You can also specify a default value that will be sent across the interface. 


### PR DESCRIPTION
Kyle I liked your comment and our discussion about this.  After looking into some of the REDCap field options, I thought a "Field Annotation" was the right place to put this.  In my local, I gave the field annotation of `pmiRdrHardCodeValue="RAB"` to `rw_workspace_review_status2`, I think this is cleaner than the previous one, and more in line with your original thinking.  

In recent conversations with Ryan and Laura, the real critical piece across the API is the display decision.   This is a required field, so I am updating this to work with the "default" action tag too.  When this is deployed, we'll need to do these updates: 
- `rw_workspace_review_status2` needs `pmiRdrHardCodeValue="RAB"`
- `rw_workspace_disp_decision` needs `@DEFAULT="UNSET" used in the PMI / RDR Module to send to RDR. Do not edit this field`