### PR TITLE
Change checkbox name approach, reverse logic for filtering out existing data

### DIFF
--- a/PmiRdrModule.php
+++ b/PmiRdrModule.php
@@ -243,7 +243,7 @@ class PmiRdrModule extends \ExternalModules\AbstractExternalModule {
 							## "___[raw_value]" is used to map checkboxes one value at a time
 							if(preg_match("/\\_\\_\\_([0-9a-zA-Z]+$)/",$redcapField,$checkboxMatches)) {
 								$checkboxValue = $checkboxMatches[1];
-								$checkboxFieldName = substr($redcapField,0,strlen($checkboxMatches) - strlen($checkboxMatches[0]));
+								$checkboxFieldName = substr($redcapField,0, (strlen($checkboxMatches[0])*-1));
 
 								if(!array_key_exists($checkboxFieldName,$rowData)) {
 									$rowData[$checkboxFieldName] = [];
@@ -260,7 +260,7 @@ class PmiRdrModule extends \ExternalModules\AbstractExternalModule {
 							## Filter out data is already exists in REDCap
 							$dataToSave = [];
 							foreach($rowData as $fieldName => $newValue) {
-								if(!empty($data[$fieldName])) {
+								if(empty($data[$fieldName])) {
 									$dataToSave[$fieldName] = $newValue;
 								}
 							}


### PR DESCRIPTION
I walked through this pipe import process via xdebug and I got the pipe version working locally with two fixes:

1.  Change approach to getting checkboxes
`$checkboxFieldName = substr($redcapField,0,strlen($checkboxMatches) - strlen($checkboxMatches[0]));`
This line was causing an error because `$checkboxMatches` was an array.  I think the intent here was to remove the trailing "___2" to get the checkbox name, so I changed the approach here. I suspect this was the main reason this process was failing

2.  reverse logic to filter out fields with existing data
```								
if(!empty(!$data[$fieldName])) {
	$dataToSave[$fieldName] = $newValue;
}
```
this code was only saving variables if the existing variable had data in it. So by my reading, this was only overwriting fields and not saving fields that were empty.  I confirmed this in xdebug.  Reversing this logic made it so only empty fields were imported.

UPDATE: I was able to confirm that `strlen($checkboxMatches)` was causing errors and stopping the import from happening.  This is the smoking gun of this ticket.  But i'm unsure how this error got introduced.
  
https://console.cloud.google.com/logs/query;query=resource.type%3D%22gae_app%22%0Alog_name%3D%22projects%2Faou-redcap-prod%2Flogs%2Fstderr%22%0AtextPayload%3D~%22.*The%20'vanderbilt_pmiRdr'%20module%20threw%20the%20following%20exception%20when%20calling%20the%20hook%20method%20'redcap_save_record':*%22;cursorTimestamp=2024-09-18T22:33:26.668860Z;duration=P30D?referrer=search&serviceId=default&versionId=workbench-report-update&authuser=0&project=aou-redcap-prod


 
![Screenshot 2024-09-20 111436](https://github.com/user-attachments/assets/713941c5-4d1d-40da-b759-3f9494807662)
