### PR TITLE
Remove incorrect php version values from config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -169,8 +169,6 @@
 	],
 
 	"compatibility": {
-		"php-version-min": "",
-		"php-version-max": "",
 		"redcap-version-min": "",
 		"redcap-version-max": ""
 	}


### PR DESCRIPTION
I'm trying to finish the creds rotation on staging, and to do that I need to enable the pmiRdr module.  That errors out with this issue:

![Screenshot 2024-09-26 134915](https://github.com/user-attachments/assets/8005331e-1b1e-4c8a-8c9f-42da50f1a409)

I spoke with Mark McEver about this, and the issue is that it is invalid if these are empty strings. they need to be actual php versions or not included at all.  This is an important fix because if our module gets disabled, we can't re-enable it until we deploy this fix. 