### PR TITLE
remove error message that is no longer needed

### DIFF
--- a/PmiRdrModule.php
+++ b/PmiRdrModule.php
@@ -292,7 +292,6 @@ class PmiRdrModule extends \ExternalModules\AbstractExternalModule {
 
 	## RDR Cron method to pull data in
 	public function rdr_pull($debugApi = false,$singleRecord = false) {
-		error_log("RDR: Ran pull cron");
 		
 		if(is_array($debugApi)) {
 			## When run from the cron, an array is passed in here

--- a/PmiRdrModule.php
+++ b/PmiRdrModule.php
@@ -178,7 +178,6 @@ class PmiRdrModule extends \ExternalModules\AbstractExternalModule {
 						$results = $httpClient->post($thisUrl,["json" => $exportData]);
 						if($results->getStatusCode() != 200) {
 							$message = $results->getBody()->getContents();
-							error_log("RDR Test: ".var_export($results->getHeaders(),true));
 							error_log("RDR Test: ".var_export($message,true));
 
 							\REDCap::logEvent("Pushed decision to RDR","Failed: \n".$message,"",$record,$event_id,$project_id);


### PR DESCRIPTION
This error log was used when I was testing the snapshot display decision months ago, and it is bloating the logs and no longer needed
