### PR TITLE
add debugging for strlen issue

### DIFF
--- a/PmiRdrModule.php
+++ b/PmiRdrModule.php
@@ -246,6 +246,9 @@ class PmiRdrModule extends \ExternalModules\AbstractExternalModule {
 							## "___[raw_value]" is used to map checkboxes one value at a time
 							if(preg_match("/\\_\\_\\_([0-9a-zA-Z]+$)/",$redcapField,$checkboxMatches)) {
 								$checkboxValue = $checkboxMatches[1];
+								if(!is_string($checkboxMatches[0])){
+									error_log("RDR Test: strlen issue: ".var_export($checkboxMatches[0],true));
+								}
 								$checkboxFieldName = substr($redcapField,0, (strlen($checkboxMatches[0])*-1));
 
 								if(!array_key_exists($checkboxFieldName,$rowData)) {
@@ -426,6 +429,12 @@ class PmiRdrModule extends \ExternalModules\AbstractExternalModule {
 						## "___[raw_value]" is used to map checkboxes one value at a time
 						if(preg_match("/\\_\\_\\_([0-9a-zA-Z]+$)/",$redcapField,$checkboxMatches)) {
 							$checkboxValue = $checkboxMatches[1];
+							if(!is_string($redcapField)){
+								error_log("RDR Test: strlen issue: ".var_export($redcapField,true));
+							}
+							if(!is_string($checkboxMatches[0])){
+								error_log("RDR Test: strlen issue: ".var_export($checkboxMatches[0],true));
+							}
 							$checkboxFieldName = substr($redcapField,0,strlen($redcapField) - strlen($checkboxMatches[0]));
 
 							if(!array_key_exists($checkboxFieldName,$rowData)) {


### PR DESCRIPTION
getting this error in prod:
```
External Module Prefix: vanderbilt_pmiRdrSubject: External Module Exception in Cron JobURL: https://redcap.pmi-ops.org/cron.phpServer: redcap.pmi-ops.org (localhost)User: SYSTEMRun Time: 7 secondsCron job 'rdr_cron' failed for External Module 'vanderbilt_pmiRdr'.Exception: TypeError: strlen(): Argument #1 ($string) must be of type string, array given in /workspace/modules/vanderbilt_pmiRdr_v1.0/PmiRdrModule.php:416Stack trace:#0 /workspace/modules/vanderbilt_pmiRdr_v1.0/PmiRdrModule.php(416): strlen(Array)#1 /workspace/redcap_v15.0.26/ExternalModules/classes/ExternalModules.php(6557): PmiModule\PmiRdrModule\PmiRdrModule->rdr_pull(false)#2 /workspace/redcap_v15.0.26/Classes/Cron.php(348): ExternalModules\ExternalModules::callCronMethod('7', 'rdr_cron')#3 /workspace/redcap_v15.0.26/cron.php(23): Cron->execute()#4 /workspace/cron.php(39): include('/workspace/redc...')#5 /workspace/index.php(147): require('/workspace/cron...')#6 {main}
```

This job has been down since 2025-06-12 15:22:32.

I am trying to see the error by adding this debugging
